### PR TITLE
Fix simulation files

### DIFF
--- a/simulation/mix_wav.py
+++ b/simulation/mix_wav.py
@@ -370,7 +370,7 @@ def main(args):
     if not os.path.isdir(os.path.join(save_dir, 'mix')):
         os.mkdir(os.path.join(save_dir, 'mix'))
     if not os.path.isdir(os.path.join(save_dir, 'reverb_ref')):
-        os.mkdir(os.path.join(save_dir, 'ref'))
+        os.mkdir(os.path.join(save_dir, 'reverb_ref'))
     if not os.path.isdir(os.path.join(save_dir, 'noreverb_ref')):
         os.mkdir(os.path.join(save_dir, 'noreverb_ref'))
     if args.generate_config: 

--- a/simulation/prepare.sh
+++ b/simulation/prepare.sh
@@ -2,16 +2,17 @@
 
 # arrowhyx@foxmail.com
 # do not forget to replace those path with correct path
+strorage_dir=$1
 
-aishell_1='/data/simu/aishell_1/' 
-aishell_3='/data/simu/aishell_3/'
-vctk='/data/simu/vctk/'
-librispeech='/data/simu/librispeech_360/'
-musan='/data/simu/musan/'
-audioset='/data/simu/audioset/'
-linear='/data/simu_rirs/linear/'
-circle='/data/simu_rirs/circle/' 
-non_uniform='/data/simu_rirs/non_uniform/' 
+aishell_1=$strorage_dir/source_datasets/aishell_1/
+aishell_3=$strorage_dir/source_datasets/aishell_3/
+vctk=$strorage_dir/source_datasets/vctk/
+librispeech=$strorage_dir/source_datasets/librispeech_360/
+musan=$strorage_dir/noise_datasets/musan/
+audioset=$strorage_dir/noise_datasets/audioset/
+linear=$strorage_dir/linear/
+circle=$strorage_dir/circle/
+non_uniform=$strorage_dir/non_uniform/
 
 selected_lists_path='../selected_lists/'
 

--- a/simulation/quick_select.py
+++ b/simulation/quick_select.py
@@ -8,7 +8,7 @@ import sys
 def func(target, source):
     
     table = {}
-    print(target, source)
+    # print(target, source)
     with open(source,'r') as fid:
         for line in fid:
             path = line.strip()


### PR DESCRIPTION
Hello, 

I tried to run the scripts and came across some errors that I believe are mistakes in the code (please correct me if I'm wrong).
I also took the liberty to add an argument to `prepare.sh` to make it more useable.
I fixed them and the script ran successfully.

I would also like you to clarify a point that is unclear to me.
The `Training_set.zip` downloaded from Dropbox contains `linear_rir.zip` `non_linear_rir.zip` and `circle_rir.zip`
Am I correct when I assume that this files have to be unzipped and renamed `linear`  `non_uniform` and `circle` 
to match the `prepare.sh` and the `selected_lists` folder expectations ?
And is that correct that these folders that are in the `Training_set` directory also contains the RIRs for the `Development _test_set` ? 

Finally can you give an estimation of the amount storage space needed to store the simulated data ? 